### PR TITLE
Fix Ruby 2.4.1

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--color

--- a/lib/travis/encrypt/base.rb
+++ b/lib/travis/encrypt/base.rb
@@ -11,6 +11,7 @@ module Travis
       end
 
       def create_aes(mode = :encrypt, key, iv)
+        key = key[0, 32] # https://github.com/ruby/ruby/commit/ce635262f53b760284d56bb1027baebaaec175d1
         aes = OpenSSL::Cipher::AES.new(256, :CBC)
         aes.send(mode)
         aes.key = key


### PR DESCRIPTION
OpenSSL has made this change: https://github.com/ruby/ruby/commit/ce635262f53b760284d56bb1027baebaaec175d1

It seems previously it has truncated our key ("Currently they just truncate the input ..."), so this change should be non-breaking.